### PR TITLE
gem install時にtty-promptも一緒に入ってほしい

### DIFF
--- a/kakutaniquiz.gemspec
+++ b/kakutaniquiz.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "tty-prompt"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
何もない環境で`gem build`して`gem install`しようとしたときに`tty-prompt`gemが足りなくて困ってしまうのでspecに依存を追加しました